### PR TITLE
fix: make report bug form scrollable and fully visible

### DIFF
--- a/app/components/Home/ReportBugForm.tsx
+++ b/app/components/Home/ReportBugForm.tsx
@@ -66,7 +66,7 @@ function ReportBugForm({ onClose }: ReportBugFormProps) {
       onClick={closeReportBugForm}
       ref={modalRef}
     >
-      <div className="bg-white shadow-lg rounded-lg flex flex-col max-w-lg p-8 w-full">
+      <div className="bg-white shadow-lg rounded-lg flex flex-col max-w-lg max-h-[90vh] overflow-y-auto p-8 w-full">
         <h2 className="text-lg font-bold mb-4">Report a Bug</h2>
 
         <form onSubmit={handleSubmit}>


### PR DESCRIPTION
Fixes #7

### Summary
- Added `max-h-[90vh]` to limit modal height to 90% of viewport
- Added `overflow-y-auto` to enable vertical scrolling when content exceeds height
- Ensures the bug report form is fully visible and scrollable on all screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)